### PR TITLE
Update spec/polyfill

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -66,16 +66,16 @@ contributors: Michał Wadas
 </emu-clause>
 
 <emu-clause id="Set.prototype.intersect">
-    <h1>Set.prototype.intersect(..._iterables_)</h1>
+    <h1>Set.prototype.intersect(..._items_)</h1>
     <emu-import href="./set-prototype-intersect.html"></emu-import>
 </emu-clause>
 
 <emu-clause id="Set.prototype.subtract">
-    <h1>Set.prototype.subtract(..._iterables_)</h1>
+    <h1>Set.prototype.subtract(..._items_)</h1>
     <emu-import href="./set-prototype-subtract.html"></emu-import>
 </emu-clause>
 
 <emu-clause id="Set.prototype.symmetricDifference">
-    <h1>Set.prototype.symmetricDifference(..._iterables_)</h1>
+    <h1>Set.prototype.symmetricDifference(..._items_)</h1>
     <emu-import href="./set-prototype-symmetric-difference.html"></emu-import>
 </emu-clause>

--- a/spec/set-prototype-remove-elements.html
+++ b/spec/set-prototype-remove-elements.html
@@ -9,8 +9,8 @@
     5. Let _remover_ be ? Get(_set_, "delete")
     6. If IsCallable(_remover_) is *false*, throw a *TypeError* exception.
     7. Repeat while _k_ < _len_
-        1. Let _kValue_ be _items_[_k_].
-        2. Call(_remover_, _set_, _kValue_)
+        1. Let _value_ be _items_[_k_].
+        2. Call(_remover_, _set_, _value_)
         3. Increase _k_ by 1.
     8. Return _set_.
 

--- a/spec/set-prototype-subtract.html
+++ b/spec/set-prototype-subtract.html
@@ -7,7 +7,7 @@
         1. If Type(_set_) is not Object, throw a *TypeError* exception.
     4. Let _k_ be 0.
     5. Let _Ctr_ be ? SpeciesConstructor(_set_, %Set%)
-    6. Let _newSet_ be ? Construct(_Ctr_)
+    6. Let _newSet_ be ? Construct(_Ctr_, _set_)
     7. Let _remover_ be ? Get(_newSet_, "delete").
     8. If IsCallable(_remover_) is *false*, throw a *TypeError* exception.
     9. Repeat while _k_ < _len_
@@ -21,7 +21,7 @@
             4. Let _status_ be Call(_remover_, _newSet_, « _nextValue_.[[Value]] »)
             5. If _status_ is an abrupt completion, return IteratorClose(_iter_, _status_)
             5. Increase _k_ by 1.
-        12. Return _newSet_.
+    10. Return _newSet_.
 
 
 </emu-alg>

--- a/spec/set-prototype-union.html
+++ b/spec/set-prototype-union.html
@@ -7,7 +7,7 @@
         1. If Type(_set_) is not Object, throw a *TypeError* exception.
     4. Let _k_ be 0.
     5. Let _Ctr_ be ? SpeciesConstructor(_set_, %Set%)
-    6. Let _newSet_ be ? Construct(_Ctr_)
+    6. Let _newSet_ be ? Construct(_Ctr_, _set_)
     7. Let _adder_ be ? Get(_newSet_, "add").
     8. If IsCallable(_adder_) is *false*, throw a *TypeError* exception.
     9. Repeat while _k_ < _len_

--- a/test/remove_elements.spec.js
+++ b/test/remove_elements.spec.js
@@ -2,10 +2,24 @@
 
 const {assert} = require('chai');
 
-describe.skip('Set.prototype.removeElements', () => {
+describe('Set.prototype.removeElements', () => {
     it('Should be present', () => {
         const set = new Set();
         assert.isFunction(set.removeElements);
         assert.isFunction(Set.prototype.removeElements);
-    })
+    });
+
+    it('Should remove elements from Set', () => {
+        const set = new Set([1, 2, 3]);
+        const actual = set.removeElements(1, 2);
+        const expected = new Set([3]);
+        assert.deepEqual(actual, expected);
+    });
+
+    it('Should not remove elements if they dont exist', () => {
+        const set = new Set([1, 2, 3]);
+        const actual = set.removeElements(4, 5);
+        const expected = new Set([1, 2, 3]);
+        assert.deepEqual(actual, expected);
+    });
 })

--- a/test/subtract.spec.js
+++ b/test/subtract.spec.js
@@ -2,10 +2,52 @@
 
 const {assert} = require('chai');
 
-describe.skip('Set.prototype.subtract', () => {
+describe('Set.prototype.subtract', () => {
     it('Should be present', () => {
         const set = new Set();
         assert.isFunction(set.subtract);
         assert.isFunction(Set.prototype.subtract);
-    })
+    });
+
+    it('Should subtract elements from single Set', () => {
+        const set = new Set([1, 2]);
+        const otherSet = new Set([1, 3]);
+        const actual = set.subtract(otherSet);
+        const expected = new Set([2]);
+        assert.deepEqual(...actual, ...expected);
+        assert.instanceOf(actual, Set);
+        assert.strictEqual(actual.constructor, Set);
+    });
+
+    it('Should subtract elements from single Array', () => {
+        const set = new Set([1, 2]);
+        const otherArray = [1, 3];
+        const actual = set.subtract(otherArray);
+        const expected = new Set([2]);
+        assert.deepEqual(actual, expected);
+        assert.instanceOf(actual, Set);
+        assert.strictEqual(actual.constructor, Set);
+    });
+
+    it('Should subtract elements from multiple Sets', () => {
+        const set = new Set([1, 2, 3]);
+        const set2 = new Set([1, 4]);
+        const set3 = new Set([2, 5]);
+        const actual = set.subtract(set2, set3);
+        const expected = new Set([3]);
+        assert.deepEqual(actual, expected);
+        assert.instanceOf(actual, Set);
+        assert.strictEqual(actual.constructor, Set);
+    });
+
+    it('Should subtract elements from multiple iterables', () => {
+        const set = new Set([1, 2, 3]);
+        const set2 = new Set([1, 4]);
+        const set3 = [2, 5];
+        const actual = set.subtract(set2, set3);
+        const expected = new Set([3]);
+        assert.deepEqual(actual, expected);
+        assert.instanceOf(actual, Set);
+        assert.strictEqual(actual.constructor, Set);
+    });
 })

--- a/test/union.spec.js
+++ b/test/union.spec.js
@@ -14,52 +14,46 @@ describe('Set.prototype.union', () => {
         assert.throws(()=>union([]));
     });
 
-    it('Should throw when called on invalid receiver', () => {
-        const union = Set.prototype.union;
-        assert.throws(()=>Reflect.apply(union, {}, [new Set()]));
-    });
-
-
     it('Should add elements from single Set', () => {
         const set = new Set([1, 2]);
-        const otherSet = new Set([4, 5]);
-        const resultSet = set.union(otherSet);
-        const elements = [...resultSet];
-        assert.deepEqual(elements, [1, 2, 4, 5]);
-        assert.instanceOf(resultSet, Set);
-        assert.strictEqual(resultSet.constructor, Set);
+        const otherSet = new Set([1, 4, 5]);
+        const actual = set.union(otherSet);
+        const expected = new Set([1, 2, 4, 5]);
+        assert.deepEqual(actual, expected);
+        assert.instanceOf(actual, Set);
+        assert.strictEqual(actual.constructor, Set);
     });
 
     it('Should add elements from single Array', () => {
         const set = new Set([1, 2]);
-        const otherArray = [4, 5];
-        const resultSet = set.union(otherArray);
-        const elements = [...resultSet];
-        assert.deepEqual(elements, [1, 2, 4, 5]);
-        assert.instanceOf(resultSet, Set);
-        assert.strictEqual(resultSet.constructor, Set);
+        const otherArray = [1, 4, 5];
+        const actual = set.union(otherArray);
+        const expected = new Set([1, 2, 4, 5]);
+        assert.deepEqual(actual, expected);
+        assert.instanceOf(actual, Set);
+        assert.strictEqual(actual.constructor, Set);
     });
 
     it('Should add elements from multiple Sets', () => {
         const set = new Set([1, 2]);
-        const set2 = new Set([4, 5]);
-        const set3 = new Set([6, 7]);
-        const resultSet = set.union(set2, set3);
-        const elements = [...resultSet];
-        assert.deepEqual(elements, [1, 2, 4, 5, 6, 7]);
-        assert.instanceOf(resultSet, Set);
-        assert.strictEqual(resultSet.constructor, Set);
+        const set2 = new Set([1, 4, 5]);
+        const set3 = new Set([4, 6, 7]);
+        const actual = set.union(set2, set3);
+        const expected = new Set([1, 2, 4, 5, 6, 7]);
+        assert.deepEqual(actual, expected);
+        assert.instanceOf(actual, Set);
+        assert.strictEqual(actual.constructor, Set);
     });
 
-    it('Should add elements from multiple Sets', () => {
+    it('Should add elements from multiple iterables', () => {
         const set = new Set([1, 2]);
-        const set2 = new Set([4, 5]);
-        const set3 = [6, 7];
-        const resultSet = set.union(set2, set3);
-        const elements = [...resultSet];
-        assert.deepEqual(elements, [1, 2, 4, 5, 6, 7]);
-        assert.instanceOf(resultSet, Set);
-        assert.strictEqual(resultSet.constructor, Set);
+        const set2 = new Set([1, 4, 5]);
+        const set3 = [4, 6, 7];
+        const actual = set.union(set2, set3);
+        const expected = new Set([1, 2, 4, 5, 6, 7]);
+        assert.deepEqual(actual, expected);
+        assert.instanceOf(actual, Set);
+        assert.strictEqual(actual.constructor, Set);
     });
 
     describe.skip('Subclassing without overwriting @@species', () => {


### PR DESCRIPTION
Spec changes

- Fixed #6 (create a new set with items populated in both union and subtract)
- Changed .subtract to return newSet after iteration is done
- Use 'items' instead of 'iterables' to be more consistent

Polyfill changes

- Added SpeciesConstructor, isObject, isCallable
- Removed un spec'd xor
- Updated subtract, union, removeElements

Added tests